### PR TITLE
snabbtop-for-next: Fix bugs in counter.delete and mkdir

### DIFF
--- a/src/core/counter.lua
+++ b/src/core/counter.lua
@@ -55,15 +55,15 @@ function open (name, readonly)
 end
 
 function delete (name)
-   local ptr = public[numbers[name]]
-   if not ptr then error("counter not found for deletion: " .. name) end
+   local number = numbers[name]
+   if not number then error("counter not found for deletion: " .. name) end
    -- Free shm object
-   shm.unmap(ptr)
+   shm.unmap(public[number])
    shm.unlink(name)
    -- Free local state
    numbers[name] = false
-   public[ptr] = false
-   private[ptr] = false
+   public[number] = false
+   private[number] = false
 end
 
 -- Copy counter private counter values to public shared memory.

--- a/src/core/shm.lua
+++ b/src/core/shm.lua
@@ -103,6 +103,11 @@ end
 -- Make directories needed for a named object.
 -- Given the name "foo/bar/baz" create /var/run/foo and /var/run/foo/bar.
 function mkdir (name)
+   -- Create root with mode "rwxrwxrwt" (R/W for all and sticky)
+   local mask = S.umask(0)
+   S.mkdir(root, "01777")
+   S.umask(mask)
+   -- Create sub directories
    local dir = root
    name:gsub("([^/]+)",
              function (x) S.mkdir(dir, "rwxu")  dir = dir.."/"..x end)


### PR DESCRIPTION
- Fix bug in `counter.delete`  where it failed to mark public/private record as deleted.
- Make `mkdir` create `root` in mode `rwxrwxrwt`.
