### PR TITLE
Typo fixes, and a question

### DIFF
--- a/src/core/timeline.md
+++ b/src/core/timeline.md
@@ -25,7 +25,7 @@ FFI call.)
 The binary representation has three components:
 
 - header: magic number, file format version, flags.
-- entires: array of 64-byte log entries.
+- entries: array of 64-byte log entries.
 - stringtable: string constants (to referenced by their byte-index)
 
 ```
@@ -44,7 +44,7 @@ The binary representation has three components:
 ```
 
 The timeline can be read by scanning through the entries and detecting
-the first and last entries by comparing timestamps. The entires can be
+the first and last entries by comparing timestamps. The entries can be
 converted from binary data to human-readable strings by using the
 format strings that they reference.
 


### PR DESCRIPTION
I spotted two typos and fixed them (entires -> entries).

And a question: In the example, shouldn't the string `example` appear somewhere in the resulting log ("The log now contains these entries")?
